### PR TITLE
Add Mulriple Select List component

### DIFF
--- a/planacad/planificaciones/formularios/formPropuestaDesarrollo.py
+++ b/planacad/planificaciones/formularios/formPropuestaDesarrollo.py
@@ -6,3 +6,10 @@ class PropuestaDesarrolloForm(forms.ModelForm):
     class Meta:  
         model = PropuestaDesarrollo  
         exclude = ['planificacion']
+        widgets = {
+            'subcompetencias': forms.CheckboxSelectMultiple(attrs={'class': 'multiple-select-list'}),
+            'resultados_de_aprendizaje': forms.CheckboxSelectMultiple(attrs={'class': 'multiple-select-list'}),
+            'unidades': forms.CheckboxSelectMultiple(attrs={'class': 'multiple-select-list'}),
+            'bibliografias': forms.CheckboxSelectMultiple(attrs={'class': 'multiple-select-list'}),
+            'estrategias_ens': forms.CheckboxSelectMultiple(attrs={'class': 'multiple-select-list'}),
+        }

--- a/planacad/planificaciones/static/styles/global.css
+++ b/planacad/planificaciones/static/styles/global.css
@@ -17,6 +17,10 @@
     color: var(--blue);
 }
 
+/**************
+*** SIDEBAR ***
+***************/
+
 .layout__sidebar {
 }
 .layout__sidebar a {
@@ -30,6 +34,10 @@
 .layout__sidebar a:hover {
     color: var(--blue);
 }
+
+/**************
+*** SECCION ***
+***************/
 
 .seccion {
     padding-bottom: 2em;
@@ -66,6 +74,10 @@
     margin-top: 20px;
     padding: 0;
 }
+
+/**************
+*** SECCION TABLE ***
+***************/
 
 .seccion__table {
     table-layout: auto;
@@ -143,7 +155,10 @@
     font-family: Arial, Helvetica, sans-serif;
 }
 
-/* Link con lecha */
+/**************
+*** LINK CON FLECHA ***
+***************/
+
 .link-arrow {
     display: block;
     text-decoration-line: none;
@@ -157,7 +172,9 @@
     margin: 0 0.2em;
 }
 
-/* Botón solo ícono */
+/**************
+*** BOTON SOLO ICONO ***
+***************/
 .btn-icon {
     width: 2.75em;
     height: 2.75em;
@@ -169,4 +186,38 @@
 }
 .btn-icon:hover {
     box-shadow: 0px 4px 10px rgba(170, 170, 170, 0.25);
+}
+
+/**************
+*** MULTIPLE SELECT LIST ***
+***************/
+ul.multiple-select-list {
+    width: 100%;
+    padding: 0;
+    border: 1px solid #9ca3af;
+    border-radius: 5px;
+    background-color: white;
+    overflow-y: auto;
+    max-height: 22em;
+}
+
+.multiple-select-list li {
+    list-style: none;
+}
+
+.multiple-select-list li label {
+    padding: 0.8em;
+    width: 100%;
+}
+
+.multiple-select-list li:hover {
+    background-color: rgba(17, 106, 204, 0.2);
+}
+
+.multiple-select-list input {
+    width: 1.1em;
+    height: 1.1em;
+    position: relative;
+    top: 0.15em;
+    margin-right: 0.5em;
 }

--- a/planacad/planificaciones/templates/componentes.html
+++ b/planacad/planificaciones/templates/componentes.html
@@ -143,5 +143,37 @@
     </div>
   </div>
 
+  <div class="py-5"></div>
+
+  <h2>Multiple Select List</h2>
+  <p>Este componente funciona como un reemplazo al input select multiple que renderiza Django para campos ManyToMany. Para integrarlo, añadir en el FormModel correspondiente una línea así para modificar el widget por defecto.</p>
+  <pre><code>widgets = {
+    'profesor_a_cargo': forms.CheckboxSelectMultiple(attrs={'class': 'multiple-select-list'})
+}</code></pre>
+<ul id="id_resultado_de_aprendizaje" class="multiple-select-list">
+  <li><label for="id_resultado_de_aprendizaje_0"><input type="checkbox" name="resultado_de_aprendizaje" value="14" class="multiple-select-list" id="id_resultado_de_aprendizaje_0">
+Los RA alcanzados requeridos para continuar con el desarrollo de los RA de Sistemas de Gestión deberían corresponderse con Administración d</label>
+</li>
+  <li><label for="id_resultado_de_aprendizaje_1"><input type="checkbox" name="resultado_de_aprendizaje" value="7" class="multiple-select-list" id="id_resultado_de_aprendizaje_1" checked="">
+Los RA alcanzados requeridos para continuar con el
+desarrollo de los RA de Ingeniería del Software deberían
+corresponderse con Análisis de Sistemas y/o Diseño de
+Sistemas.</label>
+</li>
+  <li><label for="id_resultado_de_aprendizaje_3"><input type="checkbox" name="resultado_de_aprendizaje" value="16" class="multiple-select-list" id="id_resultado_de_aprendizaje_3">
+Resultados de aprendizajes alcanzados durante el cursado de recursos</label>
+</li>
+  <li><label for="id_resultado_de_aprendizaje_4"><input type="checkbox" name="resultado_de_aprendizaje" value="17" class="multiple-select-list" id="id_resultado_de_aprendizaje_4" checked="">
+RA aprendidos durante el cursado de la materia</label>
+</li>
+  <li><label for="id_resultado_de_aprendizaje_5"><input type="checkbox" name="resultado_de_aprendizaje" value="24" class="multiple-select-list" id="id_resultado_de_aprendizaje_5">
+Resolver situaciones problemáticas básicas, aplicando operaciones con
+vectores y matrices para que el alumno contextualice futuros campos de
+acción.</label>
+</li>
+</ul>
+
+  <div class="py-5"></div>
+
 </div>
  {% endblock %}


### PR DESCRIPTION
Este componente funciona como un reemplazo al input select multiple que renderiza Django para campos ManyToMany. Para integrarlo, añadir en el FormModel correspondiente una línea así para modificar el widget por defecto.

```
widgets = {
    'profesor_a_cargo': forms.CheckboxSelectMultiple(attrs={'class': 'multiple-select-list'})
}
```

![image](https://user-images.githubusercontent.com/48495366/144766374-eb5af34d-d0e3-4abf-872c-67e72ebe60bb.png)
