### PR TITLE
Add/PlanificacionLayoutEdicion

### DIFF
--- a/planacad/planificaciones/static/styles/bootstrap.css
+++ b/planacad/planificaciones/static/styles/bootstrap.css
@@ -6,6 +6,13 @@
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
 :root {
+    --gris-negro: #121111;
+    --gris-1: #252e3c;
+    --gris-2: #485262;
+    --gris-3: #9ca3af;
+    --gris-4: #d1d5db;
+    --gris-5: #f3f4f6;
+    --gris-blanco: #fcfdff;
     --blue: #116acc;
     --bs-blue: #116acc;
     --bs-indigo: #6610f2;
@@ -696,13 +703,15 @@ progress {
     }
 }
 @media (min-width: 1400px) {
-    .container-xxl,
     .container-xl,
     .container-lg,
     .container-md,
     .container-sm,
     .container {
         max-width: 1320px;
+    }
+    .container-xxl {
+        max-width: 1440px;
     }
 }
 .row {

--- a/planacad/planificaciones/static/styles/global.css
+++ b/planacad/planificaciones/static/styles/global.css
@@ -1,13 +1,3 @@
-* {
-    /* outline: 1px solid red; */
-}
-
-.flex__between__center {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
 .item-subnavbar {
     font-weight: 500;
     padding: 0 15px 0 15px;
@@ -47,11 +37,15 @@
     font-weight: 600;
 }
 .seccion__card {
-    background-color: var(--false-white);
+    background-color: var(--gris-blanco);
     border-radius: 5px;
     box-shadow: 0px 4px 10px rgba(170, 170, 170, 0.25);
     padding: 1.6em 1.9em;
     margin: 0.5em 0;
+}
+
+.seccion__card--edicion {
+    padding: 1.6em 6.9em;
 }
 
 .seccion__card .subtitle__message {
@@ -169,4 +163,14 @@
 }
 .btn-icon:hover {
     box-shadow: 0px 4px 10px rgba(170, 170, 170, 0.25);
+}
+
+/** UTIILIDADES **/
+.bg-gris-5 {
+    background-color: var(--gris-5);
+}
+.flex__between__center {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }

--- a/planacad/planificaciones/templates/componentes/seccion_cabecera.html
+++ b/planacad/planificaciones/templates/componentes/seccion_cabecera.html
@@ -1,0 +1,12 @@
+{% if seccion_url %}
+<a
+    href="{{seccion_url}}"
+    class="link-arrow mt-1 mb-4"
+    >{% include "iconos/chevron-left.html" %}<span>Volver</span></a
+>
+{% endif %}
+
+
+{% if titulo %}
+<h2 class="seccion__encabezado">{{titulo}}</h2>
+{% endif %}

--- a/planacad/planificaciones/templates/layouts/planificacion_layout.html
+++ b/planacad/planificaciones/templates/layouts/planificacion_layout.html
@@ -80,7 +80,7 @@
             </div>
         </div>
     </header>
-    <div class="bg-light flex-grow-1">
+    <div class="bg-gris-5 flex-grow-1">
         <div class="container-xl">
             <button
                 class="btn mt-2 collapseButton"
@@ -252,7 +252,7 @@
                             </svg>
                             EXPORTAR PLANIFICACION
                         </div>
-                        </a>                        
+                        </a>                      
                     </nav>
                 </aside>
                 <main class="col seccion px-4">

--- a/planacad/planificaciones/templates/layouts/planificacion_layout_edicion.html
+++ b/planacad/planificaciones/templates/layouts/planificacion_layout_edicion.html
@@ -1,0 +1,63 @@
+{% extends 'base.html' %} {% block content %}
+
+<div class="layout d-flex flex-column min-vh-100">
+    <header class="pt-1 pb-1 border-bottom">
+        <div class="container-xxl">
+            <div class="flex__between__center m-1">
+                <h1 class="col-md-3 h3 mb-0">
+                    <a
+                        class="item"
+                        href="{% url 'planificaciones:index' %}"
+                        style="text-decoration: none; color: inherit"
+                    >
+                        PlanAcad
+                    </a>
+                </h1>
+                <div class="flex__between__center">
+                    <h6 class="mb-0 px-2">Profesor Apellido</h6>
+                    <a class="item icon" href="">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            fill="currentColor"
+                            class="bi bi-box-arrow-right"
+                            viewBox="0 0 16 16"
+                        >
+                            <path
+                                fill-rule="evenodd"
+                                d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0v2z"
+                            />
+                            <path
+                                fill-rule="evenodd"
+                                d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z"
+                            />
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </header>
+    <header class="pt-2 pb-2 border-bottom">
+        <div class="container-xxl">
+            <div class="flex__between__center">
+                <div>
+                    <span>Comision: ---</span><br />
+                    <span>
+                        <b>Materia:</b> {{planificacion.asignatura|default:""}}
+                    </span>
+                </div>
+            </div>
+        </div>
+    </header>
+    <div class="bg-gris-5 flex-grow-1">
+        <div class="container-xl pt-4">
+            <div class="">                
+                <main class="col seccion px-4">                    
+                    {% block seccion %} replace me {% endblock %}
+                </main>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/planacad/planificaciones/templates/secciones/detalles-profesor-catedra-update.html
+++ b/planacad/planificaciones/templates/secciones/detalles-profesor-catedra-update.html
@@ -1,17 +1,12 @@
-{% extends 'layouts/planificacion_layout.html' %} {% block seccion %}
+{% extends 'layouts/planificacion_layout_edicion.html' %} {% block seccion %}
 
-<a
-    href="{% url 'planificaciones:detallesprofesorcatedra' planificacion.id %}"
-    class="link-arrow my-2 mb-5"
-    >{% include "iconos/chevron-left.html" %}<span>Volver</span></a
->
+{% url 'planificaciones:detallesprofesorcatedra' planificacion.id as url %}
+{% include 'componentes/seccion_cabecera.html' with seccion_url=url titulo="Modificar docente" %}
 
-<h2 class="seccion__encabezado"></h2>
-<div class="seccion__card">
+<div class="seccion__card seccion__card--edicion">
   {% if mensaje_exito %}
   <div class="alert alert-success">{{mensaje_exito}}</div>
   {% endif %}
-  <h3>Modificar docente</h3>
 
   <form
     id="docente-form"


### PR DESCRIPTION
El layout para pantallas de edición.
No tiene la sidebar
También se creó el componente seccion_cabecera que recibe `seccion_url` y `titulo` como props.

![image](https://user-images.githubusercontent.com/48495366/144768171-fab42d3c-dc1a-44d9-a457-d310c81efe97.png)
