### PR TITLE
fix: message when is student

### DIFF
--- a/planacad/planificaciones/templates/asignaturas/detail.html
+++ b/planacad/planificaciones/templates/asignaturas/detail.html
@@ -30,14 +30,13 @@
                     {% endif %}
 
                     {% if not planificaciones %}
-                      {% if not planificacionesDeAsignatura %}
+                      {% if not planificacionesDeAsignatura or request.user|has_group:"alumno" %}
                           <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                          <strong>No existen planificaciones!</strong>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+                            En este momento, no existen planificaciones disponibles.
                           </div>
                       {% else %}
                         <div class="alert alert-warning" role="alert">
-                          Existen planificaciones en otro estado actualmente
+                          Existen planificaciones en otro estado actualmente.
                         </div>
                         {% endif %}
                     {% endif %}


### PR DESCRIPTION
Description: Fix message when a user with student rol access to a subject without "planificaciones". 

**Before**
<img width="1440" alt="Screenshot 2023-03-20 at 00 06 53" src="https://user-images.githubusercontent.com/40902023/226237948-6f60f2c7-7079-4461-b5aa-8eb59b43241c.png">


**After**
<img width="1440" alt="Screenshot 2023-03-20 at 00 07 50" src="https://user-images.githubusercontent.com/40902023/226237909-8f7dac13-3609-4ae4-a1d9-b2aa16ee9580.png">
